### PR TITLE
修复通过网页缓存刷新抽卡记录的功能

### DIFF
--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/GachaLog/QueryProvider/GachaLogQueryWebCacheProvider.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/GachaLog/QueryProvider/GachaLogQueryWebCacheProvider.cs
@@ -110,8 +110,8 @@ public sealed partial class GachaLogQueryWebCacheProvider : IGachaLogQueryProvid
             stream.ReadExactly(span);
 
             ReadOnlySpan<byte> match = isOversea
-                ? "https://gs.hoyoverse.com/genshin/event/e20190909gacha-v3/index.html"u8
-                : "https://webstatic.mihoyo.com/hk4e/event/e20190909gacha-v3/index.html"u8;
+                ? "https://gs.hoyoverse.com/genshin/event/e20190909gacha"u8
+                : "https://webstatic.mihoyo.com/hk4e/event/e20190909gacha"u8;
 
             int index = span.LastIndexOf(match);
             if (index >= 0)


### PR DESCRIPTION
<!--- Hi, thanks for considering make a PR contribution to Snap Hutao, we appreciate your work. -->
<!--- Before you create this PR, please check our contribution guide (https://hut.ao/en/development/contribute.html) and fill out the following form and checklist -->

## Description

<!--- Describe your changes -->

### 问题原理

在 6.7 版本更新后，祈愿详情页面的 URL 发生了变化：
```
6.6: https://webstatic.mihoyo.com/hk4e/event/e20190909gacha-v3/index.html
6.7: https://webstatic.mihoyo.com/hk4e/event/e20190909gacha-df01aea2/index.html
```

程序中使用 `https://webstatic.mihoyo.com/hk4e/event/e20190909gacha-v3/index.html` 进行匹配，因此无法匹配到 6.7 版本的 URL

### 更改说明

更改用于匹配的字符串

```
File: GachaLogQueryWebCacheProvider.cs

CN:
old: https://webstatic.mihoyo.com/hk4e/event/e20190909gacha-v3/index.html
new: https://webstatic.mihoyo.com/hk4e/event/e20190909gacha

OS:
old: https://gs.hoyoverse.com/genshin/event/e20190909gacha-v3/index.html
new: https://gs.hoyoverse.com/genshin/event/e20190909gacha
```

### 参考资料

https://github.com/Scighost/Starward/issues/1876

## Related Issue

<!--- If there's an associated issue, please use [GitHub Keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) to link it -->
<!-- e.g. fix #999, resolve #999, close #999 -->

暂无

## Checklist

- [x] The target PR branch is `develop` branch
