### PR TITLE
fix: restore window from notification area

### DIFF
--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/UI/Content/XamlContextExtension.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/UI/Content/XamlContextExtension.cs
@@ -16,11 +16,11 @@ public static class XamlContextExtension
         }
     }
 
-    extension(XamlRoot xamlRoot)
+    extension(XamlRoot? xamlRoot)
     {
         public XamlContext? XamlContext()
         {
-            return xamlRoot.ContentIsland?.AppData as XamlContext;
+            return xamlRoot?.ContentIsland?.AppData as XamlContext;
         }
     }
 }

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/UI/Shell/NotifyIconController.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/UI/Shell/NotifyIconController.cs
@@ -227,6 +227,7 @@ public sealed partial class NotifyIconController : IDisposable
                     currentXamlWindowReference.Window = mainWindow;
                     mainWindow.SwitchTo();
                     mainWindow.AppWindow.MoveInZOrderAtTop();
+                    mainWindow.Activate();
                     return;
                 }
 


### PR DESCRIPTION
## Description

Fixes an issue where the main window could not be restored from the notification area after the previous window instance had been destroyed.

- Explicitly activates a newly recreated main window.
- Allows XAML context lookup to tolerate a null `XamlRoot` during window teardown.

## Related Issue

No related issue.

## Testing

- [x] Debug build completes successfully.
- [x] Manually verified that the window can be minimized or closed to the notification area and restored repeatedly.

## Checklist

- [x] The target PR branch is `dev` branch.
