### PR TITLE
ci: 接入 Mirror酱 (MirrorChyan) 分发

### DIFF
--- a/.github/workflows/mirrorchyan_release.yml
+++ b/.github/workflows/mirrorchyan_release.yml
@@ -1,0 +1,46 @@
+name: mirrorchyan_release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        default: ''
+        required: false
+  release:
+    types: [published]
+
+jobs:
+  mirrorchyan:
+    runs-on: macos-latest
+    if: ${{ github.repository_owner == 'SnapHutaoRemasteringProject' }}
+
+    steps:
+      - uses: MirrorChyan/uploading-action@v1
+        with:
+          filetype: latest-release
+          filename: 'Snap.Hutao.Remastered-*-Setup.exe'
+          mirrorchyan_rid: SnapHutaoRemastered
+          tag: ${{ inputs.tag }}
+
+          os: win
+          arch: x64
+
+          owner: SnapHutaoRemasteringProject
+          repo: Snap.Hutao.Remastered
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}
+
+      - uses: MirrorChyan/uploading-action@v1
+        with:
+          filetype: latest-release
+          filename: 'Snap.Hutao.Remastered-*.msix'
+          mirrorchyan_rid: SnapHutaoRemastered_msix
+          tag: ${{ inputs.tag }}
+
+          os: win
+          arch: x64
+
+          owner: SnapHutaoRemasteringProject
+          repo: Snap.Hutao.Remastered
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}

--- a/.github/workflows/mirrorchyan_release.yml
+++ b/.github/workflows/mirrorchyan_release.yml
@@ -13,29 +13,22 @@ jobs:
   mirrorchyan:
     runs-on: macos-latest
     if: ${{ github.repository_owner == 'SnapHutaoRemasteringProject' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: SnapHutaoRemastered
+            filename: 'Snap.Hutao.Remastered-*-Setup.exe'
+          - rid: SnapHutaoRemastered_msix
+            filename: 'Snap.Hutao.Remastered-*.msix'
 
     steps:
       - uses: MirrorChyan/uploading-action@v1
         with:
           filetype: latest-release
-          filename: 'Snap.Hutao.Remastered-*-Setup.exe'
-          mirrorchyan_rid: SnapHutaoRemastered
-          tag: ${{ inputs.tag }}
-
-          os: win
-          arch: x64
-
-          owner: SnapHutaoRemasteringProject
-          repo: Snap.Hutao.Remastered
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          upload_token: ${{ secrets.MirrorChyanUploadToken }}
-
-      - uses: MirrorChyan/uploading-action@v1
-        with:
-          filetype: latest-release
-          filename: 'Snap.Hutao.Remastered-*.msix'
-          mirrorchyan_rid: SnapHutaoRemastered_msix
-          tag: ${{ inputs.tag }}
+          filename: ${{ matrix.filename }}
+          mirrorchyan_rid: ${{ matrix.rid }}
+          tag: ${{ inputs.tag || github.event.release.tag_name }}
 
           os: win
           arch: x64

--- a/.github/workflows/mirrorchyan_release_note.yml
+++ b/.github/workflows/mirrorchyan_release_note.yml
@@ -13,24 +13,19 @@ jobs:
   mirrorchyan:
     runs-on: macos-latest
     if: ${{ github.repository_owner == 'SnapHutaoRemasteringProject' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rid:
+          - SnapHutaoRemastered
+          - SnapHutaoRemastered_msix
 
     steps:
       - id: uploading
         uses: MirrorChyan/release-note-action@v1
         with:
-          mirrorchyan_rid: SnapHutaoRemastered
-          version_name: ${{ inputs.tag }}
-
-          owner: SnapHutaoRemasteringProject
-          repo: Snap.Hutao.Remastered
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          upload_token: ${{ secrets.MirrorChyanUploadToken }}
-
-      - id: uploading_msix
-        uses: MirrorChyan/release-note-action@v1
-        with:
-          mirrorchyan_rid: SnapHutaoRemastered_msix
-          version_name: ${{ inputs.tag }}
+          mirrorchyan_rid: ${{ matrix.rid }}
+          version_name: ${{ inputs.tag || github.event.release.tag_name }}
 
           owner: SnapHutaoRemasteringProject
           repo: Snap.Hutao.Remastered

--- a/.github/workflows/mirrorchyan_release_note.yml
+++ b/.github/workflows/mirrorchyan_release_note.yml
@@ -1,0 +1,38 @@
+name: mirrorchyan_release_note
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        default: ''
+        required: false
+  release:
+    types: [edited, published]
+
+jobs:
+  mirrorchyan:
+    runs-on: macos-latest
+    if: ${{ github.repository_owner == 'SnapHutaoRemasteringProject' }}
+
+    steps:
+      - id: uploading
+        uses: MirrorChyan/release-note-action@v1
+        with:
+          mirrorchyan_rid: SnapHutaoRemastered
+          version_name: ${{ inputs.tag }}
+
+          owner: SnapHutaoRemasteringProject
+          repo: Snap.Hutao.Remastered
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}
+
+      - id: uploading_msix
+        uses: MirrorChyan/release-note-action@v1
+        with:
+          mirrorchyan_rid: SnapHutaoRemastered_msix
+          version_name: ${{ inputs.tag }}
+
+          owner: SnapHutaoRemasteringProject
+          repo: Snap.Hutao.Remastered
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}


### PR DESCRIPTION
## 概述
接入 [Mirror酱](https://mirrorchyan.com) 作为第三方分发渠道，发布后自动同步安装包与更新说明。

## 变更
- 新增 `mirrorchyan_release.yml`：上传 `Snap.Hutao.Remastered-*-Setup.exe`
- 新增 `mirrorchyan_release_note.yml`：同步 release note
- 触发：手动 `workflow_dispatch`，或 GitHub Release 发布 / 编辑时自动触发
- RID：`SnapHutaoRemastered`
- 限制运行到上游仓库（防止 fork 滥用）

## 合并后需要
在仓库 Secrets 中添加 `MirrorChyanUploadToken`（由 Mirror酱 提供）。

`ash
gh secret set MirrorChyanUploadToken --repo SnapHutaoRemasteringProject/Snap.Hutao.Remastered
`

> 需手动创建资源：https://mirrorchyan.com 后台创建 SnapHutaoRemastered 资源。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated publishing of Windows x64 installers to MirrorChyan when releases are published.
  * Added automated generation of release notes for standard and MSIX releases.
  * Added manual controls for publishing installers and release notes, including optional release tag selection.
  * Improved release distribution by keeping installers and release information synchronized across supported channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The workflows add MirrorChyan distribution for standard and MSIX packages and synchronize their release notes.
- Uploads release artifacts automatically on publication or through manual dispatch.
- Synchronizes notes for published and edited releases.
- Uses the triggering release tag when no manual tag is supplied.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because mutable third-party action tags still receive repository and MirrorChyan distribution credentials.

Both workflows continue to execute unpinned `@v1` action revisions with sensitive tokens, leaving unreviewed retagged code able to access those credentials.

**Files Needing Attention:** .github/workflows/mirrorchyan_release.yml and .github/workflows/mirrorchyan_release_note.yml
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/mirrorchyan_release.yml | Adds matrix-based MirrorChyan artifact publication and correctly preserves release-event tags, but the credential-bearing action remains referenced by a mutable tag. |
| .github/workflows/mirrorchyan_release_note.yml | Adds release-note synchronization for standard and MSIX resources, but the credential-bearing action remains referenced by a mutable tag. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Release event or manual dispatch] --> B{Workflow}
  B --> C[Artifact upload matrix]
  B --> D[Release-note matrix]
  C --> E[Standard installer resource]
  C --> F[MSIX resource]
  D --> E
  D --> F
```
</details>

<sub>Reviews (5): Last reviewed commit: ["ci: use release event tag and isolate ri..."](https://github.com/snaphutaoremasteringproject/snap.hutao.remastered/commit/ebd6902904568830450b60feee327a6803f2f8c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51254028)</sub>

<!-- /greptile_comment -->