### PR TITLE
feat: 支持通过 Shell URI 启动游戏 (fix #111)

### DIFF
--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Factory/Process/ProcessFactory.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Factory/Process/ProcessFactory.cs
@@ -103,6 +103,22 @@ public sealed class ProcessFactory
         return false;
     }
 
+    public static IProcess CreateUsingShellExecute(string arguments, string fileName, string workingDirectory)
+    {
+        global::System.Diagnostics.Process process = new()
+        {
+            StartInfo = new()
+            {
+                Arguments = arguments,
+                FileName = fileName,
+                UseShellExecute = true,
+                WorkingDirectory = workingDirectory,
+            },
+        };
+
+        return new DiagnosticsProcess(process);
+    }
+
     public static IProcess CreateUsingShellExecuteRunAs(string arguments, string fileName, string workingDirectory)
     {
         global::System.Diagnostics.Process process = new()

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Resource/Localization/SH.resx
@@ -2222,8 +2222,17 @@
   <data name="ViewModelLaunchGameSchemeNotSelected" xml:space="preserve">
     <value>尚未选择任何服务器</value>
   </data>
+  <data name="ViewModelLaunchGamePickShellUriHint" xml:space="preserve">
+    <value>请输入应用的 Shell URI，例如 shell:AppsFolder\{FamilyName}!App 或 ms-windows-store://pdp/?ProductId=...</value>
+  </data>
+  <data name="ViewModelLaunchGamePickShellUriTitle" xml:space="preserve">
+    <value>从已安装应用中选择</value>
+  </data>
+  <data name="ViewModelLaunchGameShellUriInvalid" xml:space="preserve">
+    <value>无效的 Shell URI 格式，必须以 shell: 或 ms- 开头</value>
+  </data>
   <data name="ViewModelLaunchGameSetGamePathButtonText" xml:space="preserve">
-    <value>设置游戏目录</value>
+    <value>设置游戏路径</value>
   </data>
   <data name="ViewModelLaunchGameSwitchGameAccountFail" xml:space="preserve">
     <value>切换账号失败</value>

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/FileSystem/GameFileSystemExtension.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/FileSystem/GameFileSystemExtension.cs
@@ -3,6 +3,7 @@
 
 using Snap.Hutao.Remastered.Core.ExceptionService;
 using Snap.Hutao.Remastered.Core.IO.Ini;
+using Snap.Hutao.Remastered.Service.Game.PathAbstraction;
 using System.IO;
 using System.Runtime.CompilerServices;
 
@@ -47,6 +48,15 @@ public static class GameFileSystemExtension
 
                 if (GameFileSystemGameDirectories.TryGetValue(gameFileSystem, out string? gameDirectory))
                 {
+                    return gameDirectory;
+                }
+
+                if (gameFileSystem.GameFilePath is { Length: > 0 } path
+                    && (path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+                        || path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase)))
+                {
+                    gameDirectory = string.Empty;
+                    GameFileSystemGameDirectories.Add(gameFileSystem, gameDirectory);
                     return gameDirectory;
                 }
 
@@ -183,6 +193,14 @@ public static class GameFileSystemExtension
             get
             {
                 ObjectDisposedException.ThrowIf(gameFileSystem.IsDisposed, gameFileSystem);
+
+                string gameFilePath = gameFileSystem.GameFilePath;
+                if (gameFilePath is { Length: > 0 } path
+                    && (path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+                        || path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase)))
+                {
+                    throw HutaoException.Throw($"Cannot determine game region for shell URI: {gameFilePath}");
+                }
 
                 string gameFileName = gameFileSystem.GameFileName;
                 return gameFileName.ToUpperInvariant() switch

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/FileSystem/RestrictedGamePathAccessExtension.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/FileSystem/RestrictedGamePathAccessExtension.cs
@@ -36,8 +36,14 @@ public static class RestrictedGamePathAccessExtension
             return GameFileSystemErrorKind.None;
         }
 
-        // The return value is the final game path after synchronization
-        public string PerformGamePathEntrySynchronization(string? gamePath = default)
+        /// <summary>
+        /// 同步游戏路径条目。如果路径已存在于条目列表中，则选中已有条目；
+        /// 否则将新路径添加到列表中并选中。
+        /// </summary>
+        /// <param name="gamePath">游戏路径或 Shell URI。如果为 <c>null</c>，则使用当前选中的路径。</param>
+        /// <param name="launchMethod">新路径对应的启动方式，仅在添加新条目时使用。</param>
+        /// <returns>同步后的最终游戏路径。</returns>
+        public string PerformGamePathEntrySynchronization(string? gamePath = default, GameLaunchMethod launchMethod = GameLaunchMethod.Executable)
         {
             gamePath ??= access.GamePathEntry.Value?.Path;
 
@@ -70,7 +76,7 @@ public static class RestrictedGamePathAccessExtension
                     using (releaser)
                     {
                         // The game path is not in the entries, add it to the entries.
-                        GamePathEntry newEntry = GamePathEntry.Create(gamePath);
+                        GamePathEntry newEntry = GamePathEntry.Create(gamePath, launchMethod);
                         access.GamePathEntries.Value = access.GamePathEntries.Value.Add(newEntry);
                         access.GamePathEntry.Value = newEntry;
                     }

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/GameProcessFactory.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/GameProcessFactory.cs
@@ -49,7 +49,7 @@ public sealed class GameProcessFactory
         // Command-line arguments and Island injection are not supported for shell URIs.
         if (IsShellUri(gameFilePath))
         {
-            return ProcessFactory.CreateUsingShellExecuteRunAs(string.Empty, gameFilePath, string.Empty);
+            return ProcessFactory.CreateUsingShellExecute(string.Empty, gameFilePath, string.Empty);
         }
 
         string gameDirectory = context.FileSystem.GameDirectory;

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/GameProcessFactory.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/GameProcessFactory.cs
@@ -6,6 +6,7 @@ using Snap.Hutao.Remastered.Core.Diagnostics;
 using Snap.Hutao.Remastered.Factory.Process;
 using Snap.Hutao.Remastered.Service.Game.FileSystem;
 using Snap.Hutao.Remastered.Service.Game.Launching.Context;
+using Snap.Hutao.Remastered.Service.Game.PathAbstraction;
 
 namespace Snap.Hutao.Remastered.Service.Game.Launching;
 
@@ -43,6 +44,14 @@ public sealed class GameProcessFactory
         }
 
         string gameFilePath = context.FileSystem.GameFilePath;
+
+        // Shell URI launch (packaged apps, ms-windows-store, etc.)
+        // Command-line arguments and Island injection are not supported for shell URIs.
+        if (IsShellUri(gameFilePath))
+        {
+            return ProcessFactory.CreateUsingShellExecuteRunAs(string.Empty, gameFilePath, string.Empty);
+        }
+
         string gameDirectory = context.FileSystem.GameDirectory;
 
         return launchOptions.IsIslandEnabled.Value
@@ -68,5 +77,16 @@ public sealed class GameProcessFactory
             .ToString();
 
         return ProcessFactory.CreateSuspended(commandLine, context.FileSystem.GameFilePath, context.FileSystem.GameDirectory);
+    }
+
+    /// <summary>
+    /// 判断指定的路径是否为 Shell URI（用于启动打包应用或通过协议启动）。
+    /// </summary>
+    /// <param name="path">待判断的路径或 URI。</param>
+    /// <returns>如果以 <c>shell:</c> 或 <c>ms-</c> 开头则返回 <c>true</c>；否则返回 <c>false</c>。</returns>
+    private static bool IsShellUri(string path)
+    {
+        return path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/Handler/LaunchExecutionChannelOptionsHandler.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/Handler/LaunchExecutionChannelOptionsHandler.cs
@@ -15,6 +15,13 @@ public sealed class LaunchExecutionChannelOptionsHandler : AbstractLaunchExecuti
 {
     public override ValueTask BeforeAsync(BeforeLaunchExecutionContext context)
     {
+        if (context.FileSystem.GameFilePath is { Length: > 0 } path
+            && (path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase)))
+        {
+            return ValueTask.CompletedTask;
+        }
+
         string configPath = context.FileSystem.GameConfigurationFilePath;
 
         IniElement[]? elements;

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/Handler/LaunchExecutionGameResourceHandler.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/Handler/LaunchExecutionGameResourceHandler.cs
@@ -45,6 +45,13 @@ public sealed class LaunchExecutionGameResourceHandler : AbstractLaunchExecution
 
     private static bool ShouldConvert(BeforeLaunchExecutionContext context)
     {
+        if (context.FileSystem.GameFilePath is { Length: > 0 } path
+            && (path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
         // Configuration file changed
         if (context.TryGetOption(LaunchExecutionOptionsKey.ChannelOptionsChanged, out bool changed) && changed)
         {

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/PathAbstraction/GameLaunchMethod.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/PathAbstraction/GameLaunchMethod.cs
@@ -1,0 +1,20 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Snap.Hutao.Remastered.Service.Game.PathAbstraction;
+
+/// <summary>
+/// 表示游戏的启动方式。
+/// </summary>
+public enum GameLaunchMethod
+{
+    /// <summary>
+    /// 通过传统的可执行文件（.exe）路径启动。
+    /// </summary>
+    Executable,
+
+    /// <summary>
+    /// 通过 Shell URI（如 shell:AppsFolder\... 或 ms-windows-store://...）启动打包应用。
+    /// </summary>
+    ShellUri,
+}

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/PathAbstraction/GamePathEntry.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/PathAbstraction/GamePathEntry.cs
@@ -3,21 +3,42 @@
 
 namespace Snap.Hutao.Remastered.Service.Game.PathAbstraction;
 
+/// <summary>
+/// 表示一个游戏路径条目，包含路径和启动方式。
+/// </summary>
 public sealed class GamePathEntry
 {
+    /// <summary>
+    /// 游戏路径。对于传统启动方式，这是可执行文件（.exe）的完整路径；
+    /// 对于 Shell URI 启动方式，这是 shell: 或 ms- 协议 URI。
+    /// </summary>
     [JsonPropertyName("Path")]
     public string Path { get; init; } = default!;
 
-    public static GamePathEntry Create(string path)
+    /// <summary>
+    /// 该路径对应的启动方式。
+    /// </summary>
+    [JsonPropertyName("LaunchMethod")]
+    public GameLaunchMethod LaunchMethod { get; init; } = GameLaunchMethod.Executable;
+
+    /// <summary>
+    /// 创建一个新的游戏路径条目。
+    /// </summary>
+    /// <param name="path">游戏路径或 Shell URI。</param>
+    /// <param name="method">启动方式，默认为 <see cref="GameLaunchMethod.Executable"/>。</param>
+    /// <returns>新创建的 <see cref="GamePathEntry"/> 实例。</returns>
+    public static GamePathEntry Create(string path, GameLaunchMethod method = GameLaunchMethod.Executable)
     {
         return new()
         {
             Path = path,
+            LaunchMethod = method,
         };
     }
 
+    /// <inheritdoc/>
     public override string ToString()
     {
-        return $"{{ Path = {Path} }}";
+        return $"{{ Path = {Path}, LaunchMethod = {LaunchMethod} }}";
     }
 }

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/PathAbstraction/GamePathService.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/PathAbstraction/GamePathService.cs
@@ -53,7 +53,7 @@ public sealed partial class GamePathService : IGamePathService
             }
 
             ImmutableArray<GamePathEntry>.Builder builder = launchOptions.GamePathEntries.Value.ToBuilder();
-            builder.AddRange(paths.Select(GamePathEntry.Create));
+            builder.AddRange(paths.Select(path => GamePathEntry.Create(path)));
 
             // Since all path we add are not in original list, we can skip calling PerformGamePathEntrySynchronization
             await taskContext.SwitchToMainThreadAsync();

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/UI/Xaml/View/Dialog/GameShellUriInputDialog.xaml
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/UI/Xaml/View/Dialog/GameShellUriInputDialog.xaml
@@ -1,0 +1,22 @@
+<ContentDialog
+    x:Class="Snap.Hutao.Remastered.UI.Xaml.View.Dialog.GameShellUriInputDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:shuxm="using:Snap.Hutao.Remastered.UI.Xaml.Markup"
+    Title="{shuxm:ResourceString Name=ViewModelLaunchGamePickShellUriTitle}"
+    CloseButtonText="{shuxm:ResourceString Name=ContentDialogCancelCloseButtonText}"
+    DefaultButton="Primary"
+    PrimaryButtonText="{shuxm:ResourceString Name=ContentDialogConfirmPrimaryButtonText}"
+    Style="{StaticResource DefaultContentDialogStyle}"
+    mc:Ignorable="d">
+
+    <StackPanel Spacing="12">
+        <TextBlock
+            Style="{ThemeResource CaptionTextBlockStyle}"
+            Text="{shuxm:ResourceString Name=ViewModelLaunchGamePickShellUriHint}"
+            TextWrapping="Wrap"/>
+        <TextBox Text="{x:Bind ShellUri, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+    </StackPanel>
+</ContentDialog>

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/UI/Xaml/View/Dialog/GameShellUriInputDialog.xaml.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/UI/Xaml/View/Dialog/GameShellUriInputDialog.xaml.cs
@@ -1,0 +1,60 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.UI.Xaml.Controls;
+using Snap.Hutao.Remastered.Factory.ContentDialog;
+using Snap.Hutao.Remastered.Service.Game.PathAbstraction;
+
+namespace Snap.Hutao.Remastered.UI.Xaml.View.Dialog;
+
+/// <summary>
+/// 用于输入 Shell URI 以选择已安装应用的对话框。
+/// </summary>
+[DependencyProperty<string>("ShellUri")]
+public sealed partial class GameShellUriInputDialog : ContentDialog
+{
+    private readonly IContentDialogFactory contentDialogFactory;
+
+    /// <summary>
+    /// 初始化 <see cref="GameShellUriInputDialog"/> 的新实例。
+    /// </summary>
+    /// <param name="serviceProvider">服务提供程序。</param>
+    [GeneratedConstructor(InitializeComponent = true)]
+    public partial GameShellUriInputDialog(IServiceProvider serviceProvider);
+
+    /// <summary>
+    /// 异步显示对话框并获取用户输入的 Shell URI。
+    /// </summary>
+    /// <returns>
+    /// 如果用户确认且输入了有效的 Shell URI，则返回 <c>(true, uri)</c>；
+    /// 否则返回 <c>(false, default)</c>。
+    /// </returns>
+    public async ValueTask<ValueResult<bool, string>> GetShellUriAsync()
+    {
+        ContentDialogResult result = await contentDialogFactory.EnqueueAndShowAsync(this).ShowTask.ConfigureAwait(false);
+        await contentDialogFactory.TaskContext.SwitchToMainThreadAsync();
+
+        string? uri = ShellUri;
+        if (result is ContentDialogResult.Primary && !string.IsNullOrWhiteSpace(uri))
+        {
+            string trimmed = uri.Trim();
+            if (IsValidShellUri(trimmed))
+            {
+                return new(true, trimmed);
+            }
+        }
+
+        return new(false, default!);
+    }
+
+    /// <summary>
+    /// 判断指定的字符串是否为有效的 Shell URI。
+    /// </summary>
+    /// <param name="uri">待验证的 URI 字符串。</param>
+    /// <returns>如果以 <c>shell:</c> 或 <c>ms-</c> 开头则返回 <c>true</c>；否则返回 <c>false</c>。</returns>
+    private static bool IsValidShellUri(string uri)
+    {
+        return uri.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+            || uri.StartsWith("ms-", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/UI/Xaml/View/Page/LaunchGamePage.xaml
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/UI/Xaml/View/Page/LaunchGamePage.xaml
@@ -177,6 +177,17 @@
                         </cwc:SettingsCard.Description>
                     </cwc:SettingsCard>
                     <cwc:SettingsCard
+                        ActionIcon="{shuxm:FontIcon Glyph=&#xE71E;}"
+                        ActionIconToolTip="{shuxm:ResourceString Name=ViewModelLaunchGamePickShellUriTitle}"
+                        Command="{Binding PickShellUriCommand}"
+                        Header="{shuxm:ResourceString Name=ViewModelLaunchGamePickShellUriTitle}"
+                        HeaderIcon="{shuxm:FontIcon Glyph=&#xE8A6;}"
+                        IsClickEnabled="True">
+                        <cwc:SettingsCard.Description>
+                            <TextBlock Foreground="{ThemeResource SystemErrorTextColor}" Text="{shuxm:ResourceString Name=ViewModelLaunchGamePickShellUriHint}"/>
+                        </cwc:SettingsCard.Description>
+                    </cwc:SettingsCard>
+                    <cwc:SettingsCard
                         Padding="{ThemeResource SettingsExpanderItemHasIconPadding}"
                         Command="{Binding GamePackageInstallViewModel.StartCommand}"
                         Description="{Binding GamePackageInstallViewModel.RemoteVersionText}"

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/GamePackageViewModel.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/GamePackageViewModel.cs
@@ -122,6 +122,13 @@ public sealed partial class GamePackageViewModel : Abstraction.ViewModel
 
     protected override async ValueTask<bool> LoadOverrideAsync(CancellationToken token)
     {
+        if (launchOptions.GamePathEntry.Value is { Path: { Length: > 0 } path }
+            && (path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
         if (launchGameShared.GetCurrentLaunchSchemeFromConfigurationFile() is not { } launchScheme)
         {
             return false;

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameShared.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameShared.cs
@@ -223,7 +223,15 @@ public sealed partial class LaunchGameShared
                     }
                 }
 
-                if (string.IsNullOrWhiteSpace(entry.Path) || !File.Exists(entry.Path))
+                if (string.IsNullOrWhiteSpace(entry.Path))
+                {
+                    messenger.Send(InfoBarMessage.Error(SH.ViewModelLaunchGameAdvancedStartProgramNotExists, entry.Path));
+                    return;
+                }
+
+                if (!entry.Path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+                    && !entry.Path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase)
+                    && !File.Exists(entry.Path))
                 {
                     messenger.Send(InfoBarMessage.Error(SH.ViewModelLaunchGameAdvancedStartProgramNotExists, entry.Path));
                     return;

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameShared.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameShared.cs
@@ -41,8 +41,19 @@ public sealed partial class LaunchGameShared
     [GeneratedConstructor]
     public partial LaunchGameShared(IServiceProvider serviceProvoder);
 
+    /// <summary>
+    /// 从游戏配置文件获取当前启动方案。
+    /// Shell URI 路径没有传统游戏目录，直接返回 <c>null</c>。
+    /// </summary>
     public LaunchScheme? GetCurrentLaunchSchemeFromConfigurationFile(bool showInfo = true)
     {
+        if (launchOptions.GamePathEntry.Value is { Path: { Length: > 0 } path }
+            && (path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase)))
+        {
+            return default;
+        }
+
         ChannelOptions options = gameService.GetChannelOptions();
 
         if (options.ErrorKind is ChannelOptionsErrorKind.None)

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameShared.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameShared.cs
@@ -3,6 +3,7 @@
 // Copyright (c) Millennium-Science-Technology-R-D-Inst. All rights reserved.
 // Licensed under the MIT license.
 
+using Snap.Hutao.Remastered.Core.Diagnostics;
 using Snap.Hutao.Remastered.Core.ExceptionService;
 using Snap.Hutao.Remastered.Core.Logging;
 using Snap.Hutao.Remastered.Factory.ContentDialog;
@@ -204,6 +205,26 @@ public sealed partial class LaunchGameShared
             messenger.Send(InfoBarMessage.Error(ex));
         }
     }
+
+    /// <summary>
+    /// 直接启动 Shell URI 指向的打包应用，跳过依赖启动方案的传统游戏启动管道。
+    /// </summary>
+    /// <param name="shellUri">Shell URI，如 <c>shell:AppsFolder\...</c> 或 <c>ms-...</c> 协议。</param>
+    public ValueTask LaunchShellUriAsync(string shellUri)
+    {
+        try
+        {
+            IProcess process = ProcessFactory.CreateUsingShellExecute(string.Empty, shellUri, string.Empty);
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            messenger.Send(InfoBarMessage.Error(ex));
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
     public async Task LaunchAdvancedDelayedAsync(CancellationToken token = default)
     {
         // Load delayed program entries from store (no UI dependencies)

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameViewModel.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameViewModel.cs
@@ -90,7 +90,7 @@ public sealed partial class LaunchGameViewModel : Abstraction.ViewModel, IViewMo
 
     public IReadOnlyObservableProperty<string> DisplayGamePath { get => field ??= Property.Observe(LaunchOptions.GamePathEntry, static entry => SH.FormatViewModelLaunchGameDisplayGamePath(entry?.Path)); }
 
-    public IReadOnlyObservableProperty<bool> GamePathEntryValid { get => field ??= Property.Observe(LaunchOptions.GamePathEntry, static entry => !string.IsNullOrEmpty(entry?.Path)).WithValueChangedCallback(static (v, vm) => vm.HandleGamePathEntryChangeAsync().SafeForget(), this); }
+    public IReadOnlyObservableProperty<bool> GamePathEntryValid { get => field ??= Property.Observe(LaunchOptions.GamePathEntry, static entry => entry is not null && !string.IsNullOrEmpty(entry.Path)).WithValueChangedCallback(static (v, vm) => vm.HandleGamePathEntryChangeAsync().SafeForget(), this); }
 
     public IReadOnlyObservableProperty<bool> IsIslandConnected { get => GameLifeCycle.IsIslandConnected.AsReadOnly(); }
 
@@ -151,6 +151,14 @@ public sealed partial class LaunchGameViewModel : Abstraction.ViewModel, IViewMo
 
                 await taskContext.SwitchToMainThreadAsync();
                 await TargetSchemeFilteredGameAccountsView.SetAsync(currentScheme).ConfigureAwait(true);
+
+                if (GamePathEntry.Value is { Path: { Length: > 0 } path }
+                    && (path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+                        || path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase)))
+                {
+                    return;
+                }
+
                 await GamePackageViewModel.ReloadAsync().ConfigureAwait(true);
             }
         }
@@ -276,6 +284,9 @@ public sealed partial class LaunchGameViewModel : Abstraction.ViewModel, IViewMo
     }
 
     [Command("PickGamePathCommand")]
+    /// <summary>
+    /// 打开文件选择对话框，让用户选择游戏可执行文件（.exe）作为启动路径。
+    /// </summary>
     private async Task PickGamePathAsync()
     {
         SentrySdk.AddBreadcrumb(BreadcrumbFactory.CreateUI("Set game path by picker", "LaunchGameViewModel.Command"));
@@ -286,6 +297,30 @@ public sealed partial class LaunchGameViewModel : Abstraction.ViewModel, IViewMo
 
         await taskContext.SwitchToMainThreadAsync();
         LaunchOptions.PerformGamePathEntrySynchronization(path);
+    }
+
+    [Command("PickShellUriCommand")]
+    /// <summary>
+    /// 打开 Shell URI 输入对话框，让用户输入一个已安装应用的 Shell URI 作为游戏启动路径。
+    /// </summary>
+    private async Task PickShellUriAsync()
+    {
+        SentrySdk.AddBreadcrumb(BreadcrumbFactory.CreateUI("Set game path by shell uri", "LaunchGameViewModel.Command"));
+        using (IServiceScope scope = serviceProvider.CreateScope())
+        {
+            GameShellUriInputDialog dialog = await scope.ServiceProvider
+                .GetRequiredService<IContentDialogFactory>()
+                .CreateInstanceAsync<GameShellUriInputDialog>(scope.ServiceProvider)
+                .ConfigureAwait(false);
+
+            if (await dialog.GetShellUriAsync().ConfigureAwait(false) is not (true, var uri))
+            {
+                return;
+            }
+
+            await taskContext.SwitchToMainThreadAsync();
+            LaunchOptions.PerformGamePathEntrySynchronization(uri, GameLaunchMethod.ShellUri);
+        }
     }
 
     [Command("ResetGamePathCommand")]

--- a/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameViewModel.cs
+++ b/src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameViewModel.cs
@@ -365,6 +365,14 @@ public sealed partial class LaunchGameViewModel : Abstraction.ViewModel, IViewMo
             Shared.LaunchAdvancedDelayedAsync().SafeForget();
         }
 
+        if (LaunchOptions.GamePathEntry.Value is { Path: { Length: > 0 } path }
+            && (path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase)))
+        {
+            await Shared.LaunchShellUriAsync(path).ConfigureAwait(false);
+            return;
+        }
+
         UserAndUid? userAndUid = await userService.GetCurrentUserAndUidAsync().ConfigureAwait(false);
         await Shared.DefaultLaunchExecutionAsync(this, userAndUid).ConfigureAwait(false);
     }


### PR DESCRIPTION
## 背景
Issue #111: 改进自定义启动功能，支持不只通过 .exe 路径启动游戏（如打包应用 MSIX/APPX、URI 协议等）。

## 实现方案
参考 Snap.Hutao 中已有的 shell URI 启动方式，在启动链路中增加对 shell URI 的支持。

## 变更内容

### 新建文件
- Service/Game/PathAbstraction/GameLaunchMethod.cs - 新增 Executable / ShellUri 枚举
- UI/Xaml/View/Dialog/GameShellUriInputDialog.xaml(.cs) - Shell URI 输入对话框

### 修改文件
- GamePathEntry.cs - 新增 LaunchMethod 字段（JSON 持久化）
- GameProcessFactory.cs - 检测到 shell:/ms- 协议时，跳过命令行参数和 Island 注入，直接用 ShellExecute 启动
- GameFileSystemExtension.cs - shell URI 的 GameDirectory 返回 string.Empty，避免 Path 崩溃
- RestrictedGamePathAccessExtension.cs - PerformGamePathEntrySynchronization 支持携带 LaunchMethod
- LaunchGameShared.cs - 高级启动的延迟程序支持 shell URI
- GamePackageViewModel.cs - shell URI 下跳过包状态加载
- LaunchGameViewModel.cs - 新增 PickShellUriCommand
- LaunchGamePage.xaml - 增加"从已安装应用中选择"入口
- SH.resx - 新增 3 条本地化字符串

## 已知限制
- Island 注入模式不支持 shell URI（自动降级为普通 ShellExecute）
- 命令行参数对 shell URI 不适用
- 游戏目录相关功能（config.ini、截图目录等）对 shell URI 不可用

## 测试建议
1. 在启动页点击"从已安装应用中选择"
2. 输入 shell:AppsFolder\{FamilyName}!App 格式的 URI
3. 点击启动，验证应用是否能正常拉起

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for launching games through Windows Shell URIs, including `shell:` and `ms-` paths.
  * Added a dedicated Shell URI input dialog with format validation and localized prompts.
  * Added a game-path option for entering and saving Shell URIs.
  * Game-path entries now distinguish between executable paths and Shell URI launch methods.

* **Bug Fixes**
  * Improved validation and handling of Shell URI paths without requiring filesystem access.
  * Prevented unnecessary game-package reloads and launch preparation for Shell URI launches.
  * Updated Chinese game-path labels and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds persisted Shell URI launch entries and routes them through ShellExecute while bypassing filesystem-dependent launch operations. The latest changes resolve the previously reported launch-time exceptions, but URI selection still passes an expected null scheme through warning-producing account-view logic.

- Adds `shell:` and `ms-` URI entry, persistence, validation, and launch support.
- Skips configuration, package, resource-conversion, and executable-injection behavior for Shell URIs.
- Adds a localized Shell URI input dialog and launch-page entry point.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because selecting a valid Shell URI still produces an erroneous missing-server warning.

Shell URIs intentionally resolve to no launch scheme, but the changed path applies that null scheme to the account view before returning, causing valid URI selections to be reported as missing a required server.

**Files Needing Attention:** src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameViewModel.cs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameViewModel.cs | Adds URI selection and direct launch routing, but the path-change guard remains after null-scheme account-view processing and emits a false warning. |
| src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameShared.cs | Treats Shell URIs as scheme-less and launches them directly through ShellExecute. |
| src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/GameProcessFactory.cs | Adds ShellExecute process creation for URI paths while executable launches retain their existing behavior. |
| src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/Handler/LaunchExecutionChannelOptionsHandler.cs | Prevents configuration-file access for URI-backed launches. |
| src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/Launching/Handler/LaunchExecutionGameResourceHandler.cs | Prevents resource conversion from running for URI-backed launches. |
| src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/Service/Game/PathAbstraction/GamePathEntry.cs | Persists the launch method alongside each game path while preserving executable behavior as the default. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Select Shell URI] --> B[HandleGamePathEntryChangeAsync]
    B --> C[Resolve current scheme]
    C -->|Shell URI| D[currentScheme = null]
    D --> E[SetAsync null]
    E --> F[Emit scheme-not-selected warning]
    F --> G[Shell URI guard returns]
    H[Launch command] --> I{Shell URI?}
    I -->|Yes| J[ShellExecute]
    I -->|No| K[Default launch pipeline]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2FSnap.Hutao.Remastered%2FSnap.Hutao.Remastered%2FViewModel%2FGame%2FLaunchGameViewModel.cs%3A152-162%0A**Valid%20URI%20emits%20scheme%20warning**%0A%0AWhen%20a%20user%20selects%20a%20%60shell%3A%60%20or%20%60ms-%60%20game%20path%2C%20scheme%20resolution%20intentionally%20returns%20null%2C%20but%20%60SetAsync%28currentScheme%29%60%20runs%20before%20this%20URI%20guard%20and%20reports%20that%20no%20server%20is%20selected.%20This%20displays%20a%20misleading%20warning%20even%20though%20Shell%20URI%20launches%20do%20not%20require%20a%20server%20scheme.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28GamePathEntry.Value%20is%20%7B%20Path%3A%20%7B%20Length%3A%20%3E%200%20%7D%20path%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26%26%20%28path.StartsWith%28%22shell%3A%22%2C%20StringComparison.OrdinalIgnoreCase%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%7C%20path.StartsWith%28%22ms-%22%2C%20StringComparison.OrdinalIgnoreCase%29%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20await%20taskContext.SwitchToMainThreadAsync%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20await%20TargetSchemeFilteredGameAccountsView.SetAsync%28currentScheme%29.ConfigureAwait%28true%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20await%20GamePackageViewModel.ReloadAsync%28%29.ConfigureAwait%28true%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=snaphutaoremasteringproject%2Fsnap.hutao.remastered&pr=240&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/Snap.Hutao.Remastered/Snap.Hutao.Remastered/ViewModel/Game/LaunchGameViewModel.cs:152-162
**Valid URI emits scheme warning**

When a user selects a `shell:` or `ms-` game path, scheme resolution intentionally returns null, but `SetAsync(currentScheme)` runs before this URI guard and reports that no server is selected. This displays a misleading warning even though Shell URI launches do not require a server scheme.

```suggestion
                if (GamePathEntry.Value is { Path: { Length: > 0 } path }
                    && (path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase)
                        || path.StartsWith("ms-", StringComparison.OrdinalIgnoreCase)))
                {
                    return;
                }

                await taskContext.SwitchToMainThreadAsync();
                await TargetSchemeFilteredGameAccountsView.SetAsync(currentScheme).ConfigureAwait(true);
                await GamePackageViewModel.ReloadAsync().ConfigureAwait(true);
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: enable shell URI (UWP) game launch,..."](https://github.com/snaphutaoremasteringproject/snap.hutao.remastered/commit/75bf3566f2bae7e5e957363223b1146800c2b237) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51575410)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->